### PR TITLE
Install under specific user + RedHat + Solenoid-UI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ selenoid_limit: 5 # Total number of simultaneously running containers http://aer
 selenoid_tmpfs: 128 # Add in-memory filesystem (tmpfs) to container http://aerokube.com/selenoid/latest/#_other_optional_fields
 selenoid_config_dir: "{{ ansible_env.HOME }}/selenoid" # Selenoid configuration dir
 selenoid_listen_port: 4444 # Listen port
+selenoid_ui_listen_port: 8080 # Listen port
 selenoid_time_zone: Europe/Moscow # Timezone in container
 selenoid_browsers_last_versions: 5 # How many last version browsers need download in selenoid
 selenoid_browsers: # What browsers to download
@@ -13,3 +14,4 @@ selenoid_browsers: # What browsers to download
   - chrome
 selenoid_video_host_output_dir: /var/lib/selenoid/video # Dir for save video in host path
 selenoid_video_container_output_dir: /opt/selenoid/video # Dir for save video in container (default: /opt/selenoid/video)
+selenoid_owner_user: "{{ ansible_env.USER }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-selenoid_version: 1.6.0 # Install selenoid version
-selenoid_cm_version: 1.4.2 # Install configuration manager version
+selenoid_version: 1.9.3 # Install selenoid version
+selenoid_cm_version: latest # Install configuration manager version
 selenoid_limit: 5 # Total number of simultaneously running containers http://aerokube.com/selenoid/latest/#_recommended_docker_settings
 selenoid_tmpfs: 128 # Add in-memory filesystem (tmpfs) to container http://aerokube.com/selenoid/latest/#_other_optional_fields
-selenoid_config_dir: /root/.aerokube/selenoid # Selenoid configuration dir
+selenoid_config_dir: "{{ ansible_env.HOME }}/selenoid" # Selenoid configuration dir
 selenoid_listen_port: 4444 # Listen port
 selenoid_time_zone: Europe/Moscow # Timezone in container
 selenoid_browsers_last_versions: 5 # How many last version browsers need download in selenoid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,35 @@
 ---
+# - name: Selenoid | Install certain python modules for docker
+#   pip:
+#     name: "{{ item.name }}"
+#   with_items:
+#   - { name: docker }
+
 - name: Selenoid | Install certain python modules for docker
-  pip:
+  become: True
+  package:
     name: "{{ item.name }}"
   with_items:
-  - { name: docker }
+    - { name: python-docker-py }
+  when:
+    - (ansible_distribution == "OracleLinux" or ansible_distribution == "CentOS")
+    - ansible_os_family == "RedHat"
+
+- name: Selenoid | Install certain python modules for docker
+  become: True
+  package:
+    name: "{{ item.name }}"
+  with_items:
+    - { name: python-docker }
+  when:
+    - ansible_os_family == "Debian"
+
 
 - name: Selenoid | Check selenoid container exist
-  shell: 'docker ps -aq --filter "name={{ item }}"'
+  shell: "docker ps -aq --filter \"name=^{{ item }}$\""
   with_items:
     - 'selenoid'
+    - 'selenoid-ui'
   register: found_containers
 
 - name: Selenoid | Remove selenoid container if exist
@@ -26,13 +47,18 @@
   docker_container:
     name: cm
     image: "aerokube/cm:{{ selenoid_cm_version }}"
+    # auto_remove: yes
+    # Need to remove CM container before next invocation.....
+    # But this command run for long time to download containers
+    cleanup: yes
+    detach: no
     volumes:
     - "/var/run/docker.sock:/var/run/docker.sock"
-    - "/root:/root"
+    - "{{ selenoid_config_dir }}:/root"
     - "{{ selenoid_video_host_output_dir }}:{{ selenoid_video_container_output_dir }}"
     env:
       TZ: "{{ selenoid_time_zone }}"
-      OVERRIDE_HOME: "/root"
+      OVERRIDE_HOME: "{{ selenoid_config_dir }}"
     command: >
       selenoid start
         --config-dir {{ selenoid_config_dir }}
@@ -43,3 +69,43 @@
         --force
         --vnc
         --args "-limit {{ selenoid_limit }} -listen :{{ selenoid_listen_port }} -video-output-dir={{ selenoid_video_container_output_dir }} -conf /etc/selenoid/browsers.json"
+  register: reg_cm_solenoid
+
+- name: Print some debug information
+  vars:
+    msg: |
+        reg_cm_solenoid: {{ reg_cm_solenoid }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+  tags: debug_info
+
+
+- name: Selenoid | Run CM selenoid-ui
+  docker_container:
+    name: cm
+    # auto_remove: yes
+    cleanup: yes
+    detach: no
+    image: "aerokube/cm:{{ selenoid_cm_version }}"
+    volumes:
+    - "/var/run/docker.sock:/var/run/docker.sock"
+    - "{{ selenoid_config_dir }}:/root"
+    env:
+      TZ: "{{ selenoid_time_zone }}"
+      OVERRIDE_HOME: "{{ selenoid_config_dir }}"
+      # DOCKER_API_VERSION: "{{ selenoid_docker_api_version | string }}"
+#       --args "--selenoid-uri http://selenoid:{{ selenoid_listen_port }} --webdriver-uri http://{{selenoid_host_external}}:{{ selenoid_listen_port }}"
+    command: >
+      selenoid-ui start
+  register: reg_cm_solenoidui
+
+- name: Print some debug information
+  vars:
+    msg: |
+        Ansible Distribution: {{ ansible_distribution }}
+        Ansible Dist version: {{ ansible_distribution_version }}
+        Ansible OS family {{ansible_os_family}}
+        reg_cm_solenoidui: {{ reg_cm_solenoidui }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+  tags: debug_info

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-# - name: Selenoid | Install certain python modules for docker
-#   pip:
-#     name: "{{ item.name }}"
-#   with_items:
-#   - { name: docker }
-
 - name: "Selenoid | Install certain python modules for docker (RedHat)"
   become: True
   package:
@@ -12,7 +6,6 @@
   with_items:
     - { name: python-docker-py }
   when:
-    - (ansible_distribution == "OracleLinux" or ansible_distribution == "CentOS")
     - ansible_os_family == "RedHat"
 
 - name: "Selenoid | Install certain python modules for docker (Debian)"
@@ -46,14 +39,8 @@
   tags:
     - stop_selenoid
 
-# - name: Selenoid | Create video folder
-#   become: True
-#   become_user: "{{selenoid_owner_user}}"
-#   file:
-#     path: "{{ selenoid_video_host_output_dir }}"
-#     state: directory
-#     mode: 0755
-
+    # I see that "cm" does not  mount selenoid_video_host_output_dir in according to OVERRIDE_VIDEO_OUTPUT_DIR (ignore it)
+    # so video will be in {{ selenoid_config_dir }}/.aerokube/selenoid/video:
 - name: Selenoid | Link video folder (due BUG in cm for OVERRIDE_VIDEO_OUTPUT_DIR )
   become: True
   become_user: "{{selenoid_owner_user}}"
@@ -78,23 +65,19 @@
     detach: no
     volumes:
     - "/var/run/docker.sock:/var/run/docker.sock"
+    # due cm save config to /root inside container
     - "{{ selenoid_config_dir }}:/root"
-    # - "{{ selenoid_video_host_output_dir }}:{{ selenoid_video_container_output_dir }}"
-    # due cm save config to /root
     env:
       TZ: "{{ selenoid_time_zone }}"
       OVERRIDE_HOME: "{{ selenoid_config_dir }}"
       OVERRIDE_VIDEO_OUTPUT_DIR: "{{ selenoid_video_host_output_dir }}"
     # in child container we will have mounts: "{{ selenoid_config_dir }}.aerokube/selenoid:/etc/selenoid:ro,Z"
-    # I see that "cm" does not  mount selenoid_video_host_output_dir in according to OVERRIDE_VIDEO_OUTPUT_DIR (ignore it)
-    # so video will be in {{ selenoid_config_dir }}/.aerokube/selenoid/video:
     command: >
       selenoid start
         --version {{ selenoid_version }}
         --tmpfs {{ selenoid_tmpfs }}
         --browsers {% for browser in selenoid_browsers -%}'{{ browser }}'{%- if not loop.last -%};{%- endif -%}{%- endfor %}
         --last-versions {{ selenoid_browsers_last_versions }}
-        --force
         --vnc
         --env OVERRIDE_VIDEO_OUTPUT_DIR={{ selenoid_video_host_output_dir }}
         --args "-limit {{ selenoid_limit }} -listen :{{ selenoid_listen_port }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 #   with_items:
 #   - { name: docker }
 
-- name: Selenoid | Install certain python modules for docker
+- name: "Selenoid | Install certain python modules for docker (RedHat)"
   become: True
   package:
     name: "{{ item.name }}"
@@ -15,7 +15,7 @@
     - (ansible_distribution == "OracleLinux" or ansible_distribution == "CentOS")
     - ansible_os_family == "RedHat"
 
-- name: Selenoid | Install certain python modules for docker
+- name: "Selenoid | Install certain python modules for docker (Debian)"
   become: True
   package:
     name: "{{ item.name }}"
@@ -26,24 +26,48 @@
 
 
 - name: Selenoid | Check selenoid container exist
-  shell: "docker ps -aq --filter \"name=^{{ item }}$\""
+  become: True
+  become_user: "{{selenoid_owner_user}}"
+  # Normally must be name=^{{ item }}$ but we have  seen problem on some hosts with cap (^)
+  shell: "docker ps -aq --filter \"name={{ item }}$\""
   with_items:
     - 'selenoid'
     - 'selenoid-ui'
   register: found_containers
+  tags:
+    - stop_selenoid
 
 - name: Selenoid | Remove selenoid container if exist
+  become: True
+  become_user: "{{selenoid_owner_user}}"
   shell: 'docker stop {{ item.item }} && docker rm -fv {{ item.item }}'
   with_items: '{{ found_containers.results }}'
   when: item.stdout
+  tags:
+    - stop_selenoid
 
-- name: Selenoid | Create video folder
+# - name: Selenoid | Create video folder
+#   become: True
+#   become_user: "{{selenoid_owner_user}}"
+#   file:
+#     path: "{{ selenoid_video_host_output_dir }}"
+#     state: directory
+#     mode: 0755
+
+- name: Selenoid | Link video folder (due BUG in cm for OVERRIDE_VIDEO_OUTPUT_DIR )
+  become: True
+  become_user: "{{selenoid_owner_user}}"
   file:
     path: "{{ selenoid_video_host_output_dir }}"
-    state: directory
+    state: link
+    src: "{{ selenoid_config_dir }}/.aerokube/selenoid/video"
+    force: yes
     mode: 0755
 
+
 - name: Selenoid | Run CM container, download browser images and run selenoid
+  become: True
+  become_user: "{{selenoid_owner_user}}"
   docker_container:
     name: cm
     image: "aerokube/cm:{{ selenoid_cm_version }}"
@@ -55,20 +79,25 @@
     volumes:
     - "/var/run/docker.sock:/var/run/docker.sock"
     - "{{ selenoid_config_dir }}:/root"
-    - "{{ selenoid_video_host_output_dir }}:{{ selenoid_video_container_output_dir }}"
+    # - "{{ selenoid_video_host_output_dir }}:{{ selenoid_video_container_output_dir }}"
+    # due cm save config to /root
     env:
       TZ: "{{ selenoid_time_zone }}"
       OVERRIDE_HOME: "{{ selenoid_config_dir }}"
+      OVERRIDE_VIDEO_OUTPUT_DIR: "{{ selenoid_video_host_output_dir }}"
+    # in child container we will have mounts: "{{ selenoid_config_dir }}.aerokube/selenoid:/etc/selenoid:ro,Z"
+    # I see that "cm" does not  mount selenoid_video_host_output_dir in according to OVERRIDE_VIDEO_OUTPUT_DIR (ignore it)
+    # so video will be in {{ selenoid_config_dir }}/.aerokube/selenoid/video:
     command: >
       selenoid start
-        --config-dir {{ selenoid_config_dir }}
         --version {{ selenoid_version }}
         --tmpfs {{ selenoid_tmpfs }}
         --browsers {% for browser in selenoid_browsers -%}{{ browser }}{%- if not loop.last -%},{%- endif -%}{%- endfor %}
         --last-versions {{ selenoid_browsers_last_versions }}
         --force
         --vnc
-        --args "-limit {{ selenoid_limit }} -listen :{{ selenoid_listen_port }} -video-output-dir={{ selenoid_video_container_output_dir }} -conf /etc/selenoid/browsers.json"
+        --env OVERRIDE_VIDEO_OUTPUT_DIR={{ selenoid_video_host_output_dir }}
+        --args "-limit {{ selenoid_limit }} -listen :{{ selenoid_listen_port }}"
   register: reg_cm_solenoid
 
 - name: Print some debug information
@@ -81,6 +110,8 @@
 
 
 - name: Selenoid | Run CM selenoid-ui
+  become: True
+  become_user: "{{selenoid_owner_user}}"
   docker_container:
     name: cm
     # auto_remove: yes
@@ -97,6 +128,7 @@
 #       --args "--selenoid-uri http://selenoid:{{ selenoid_listen_port }} --webdriver-uri http://{{selenoid_host_external}}:{{ selenoid_listen_port }}"
     command: >
       selenoid-ui start
+      --port {{ selenoid_ui_listen_port }}
   register: reg_cm_solenoidui
 
 - name: Print some debug information

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,7 +92,7 @@
       selenoid start
         --version {{ selenoid_version }}
         --tmpfs {{ selenoid_tmpfs }}
-        --browsers {% for browser in selenoid_browsers -%}{{ browser }}{%- if not loop.last -%},{%- endif -%}{%- endfor %}
+        --browsers {% for browser in selenoid_browsers -%}'{{ browser }}'{%- if not loop.last -%};{%- endif -%}{%- endfor %}
         --last-versions {{ selenoid_browsers_last_versions }}
         --force
         --vnc

--- a/testfile
+++ b/testfile
@@ -1,0 +1,1 @@
+test to show Artem


### PR DESCRIPTION
improvements:
install solenoid under specific user {{selenoid_owner_user}}
add parameters: selenoid_ui_listen_port selenoid_owner_user
change default selenoid_config_dir
use "package" instead of "pip"
added support of RedHat
update versions of cm and selenoid
start solenoid-ui as well
tags: stop_selenoid

bugs:
remove "--force" to avoid re-download
correct string for browsers
